### PR TITLE
can now set max connections and shared buffers size

### DIFF
--- a/dax/postgis/Chart.yaml
+++ b/dax/postgis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: postgis
 appVersion: "16-3.4"
 description: Helm chart for PostgreSQL with GIS extension.
-version: 1.2.0
+version: 1.3.0
 type: application

--- a/dax/postgis/templates/statefulset.yaml
+++ b/dax/postgis/templates/statefulset.yaml
@@ -20,6 +20,7 @@ spec:
       containers:
         - name: {{ .Release.Name }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          args: ["-c", "max_connections={{ .Values.maxConnections }}", "-c", "shared_buffers={{ .Values.sharedBuffers }}"]
           resources:
             requests:
               memory: {{ .Values.resources.requests.memory}}

--- a/dax/postgis/values.yaml
+++ b/dax/postgis/values.yaml
@@ -16,3 +16,6 @@ resources:
     memory: 1Gi
 
 serviceAnnotations: {}
+
+maxConnections: 300
+sharedBuffers: "256MB"


### PR DESCRIPTION
We have had issues where when too many users are connected to the PostGIS database the database is running out of connections. This change enables us to fine tune the `max_connections` setting and the `shared_buffers` size. When `max_connections` are changed the `shared_buffers` should also be increased.

Example going from 100 to 300 `max_connections` should increase the `shared_buffers` size to
from `128MB` to `256MB` or more.