### PR TITLE
now sets a termination grace period for the api gateway

### DIFF
--- a/dax/openftth-api-gateway/Chart.yaml
+++ b/dax/openftth-api-gateway/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openftth-api-gateway
 appVersion: "7.15.4"
 description: A Helm chart for api-gateway
-version: 1.1.108
+version: 1.2.0
 type: application

--- a/dax/openftth-api-gateway/templates/deployment.yaml
+++ b/dax/openftth-api-gateway/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: {{ .Release.Name }}
     spec:
+      terminationGracePeriodSeconds: 45
       containers:
       - name: {{ .Release.Name }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}


### PR DESCRIPTION
To avoid the application being shutdown in a not graceful way we now set the grace period to 45 seconds, the default termination time for the application is 30 seconds, so we give it a bit extra to make sure everything has been shutdown with a problem.